### PR TITLE
Fix deep-copy/deep-paste

### DIFF
--- a/packages/filebrowser-deep-copy-paste/src/index.ts
+++ b/packages/filebrowser-deep-copy-paste/src/index.ts
@@ -144,7 +144,7 @@ function activate(
           const newPath = PathExt.join(basePath, PathExt.basename(path));
           log('deep paste cut item', path);
           await manager.rename(path, newPath);
-          return;
+          break;
         }
 
         const item = await manager.services.contents.get(path, { content: true });


### PR DESCRIPTION
# Behavior
If a user selects Deep Cut, and then Deep Paste, then all subsequent Deep Copy's behave in fact as a Deep Cut, while the user expects a Deep Copy.

# Fix
Break instead of return, so that isCut may be reset.