### PR TITLE
Restore copy shareable link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,11 +1744,11 @@
 			},
 			"dependencies": {
 				"@blueprintjs/core": {
-					"version": "3.39.0",
-					"resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.39.0.tgz",
-					"integrity": "sha512-Pl92Qvfo0iowvJ81hOxfOXgBUuqHdMgtYao7hCvhF5hvz8wYRfOr1GHChVsiD5NvpNmG2rtUTYqkfft06Tyj5A==",
+					"version": "3.40.1",
+					"resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.40.1.tgz",
+					"integrity": "sha512-trZMuv84vbIJKJYZ7YkMB+Eth1H74KeJrY07pJhlbmbsGTbBc7Pj1Lx2858PgyIaO9HpaHaBS2+VPmMFkt8muw==",
 					"requires": {
-						"@blueprintjs/icons": "^3.24.0",
+						"@blueprintjs/icons": "^3.25.1",
 						"@types/dom4": "^2.0.1",
 						"classnames": "^2.2",
 						"dom4": "^2.1.5",
@@ -1762,20 +1762,20 @@
 					}
 				},
 				"@blueprintjs/icons": {
-					"version": "3.24.0",
-					"resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.24.0.tgz",
-					"integrity": "sha512-OvDDI5EUueS1Y3t594iS8LAGoHhLhYjC2GuN/01a85n+ASLSp0jf0/+uix2JeCOj41iTdRRCINbWuRwVQNNGPw==",
+					"version": "3.25.1",
+					"resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.25.1.tgz",
+					"integrity": "sha512-AppGf5IyjjKa/Zlre4pHWbDnsI7nefurXKku8Yf/B14bDAB2a8lzP6HCoTowAW4fHryTwE5Pzp9zEJYvofkUEg==",
 					"requires": {
 						"classnames": "^2.2",
 						"tslib": "~1.13.0"
 					}
 				},
 				"@blueprintjs/select": {
-					"version": "3.15.5",
-					"resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.15.5.tgz",
-					"integrity": "sha512-ZZaW60v7sKY2NIPvqG9PO+BAvbfeFvL/LQ6wNHias+T63Nk34NZrUx0a3MSELkTsJwdpZLZJLzH7c8zQANBOkg==",
+					"version": "3.15.7",
+					"resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.15.7.tgz",
+					"integrity": "sha512-PZ1hh0bQjtSwNd2n1xr+D5XCZms72soDjgjLWUIGPIZIpZjmf+WpZFXJYME9AUWw55bCDPeZ9sUBa7/XEpazQQ==",
 					"requires": {
-						"@blueprintjs/core": "^3.39.0",
+						"@blueprintjs/core": "^3.40.1",
 						"classnames": "^2.2",
 						"tslib": "~1.13.0"
 					}

--- a/packages/filebrowser-share-file/.gitignore
+++ b/packages/filebrowser-share-file/.gitignore
@@ -1,0 +1,5 @@
+*.bundle.*
+lib/
+node_modules/
+*.egg-info/
+.ipynb_checkpoints

--- a/packages/filebrowser-share-file/CHANGELOG.md
+++ b/packages/filebrowser-share-file/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.2](https://github.com/Tubitv/jupyterlab-extensions/compare/@tubitv/filebrowser-share-file@0.1.2-alpha.2...@tubitv/filebrowser-share-file@0.1.2) (2020-05-14)
+
+**Note:** Version bump only for package @tubitv/filebrowser-share-file
+
+
+
+
+
+## 0.1.2-alpha.2 (2020-05-08)
+
+**Note:** Version bump only for package @tubitv/filebrowser-share-file

--- a/packages/filebrowser-share-file/README.md
+++ b/packages/filebrowser-share-file/README.md
@@ -1,0 +1,37 @@
+# filebrowser-share-file
+
+It's a replacement of [`@jupyterlab/filebrowser-extension:share-file`](https://jupyterlab.readthedocs.io/en/stable/developer/extension_points.html#copy-shareable-link).
+
+## Prerequisites
+
+* JupyterLab >=3.0.0
+
+## Installation
+
+```bash
+# Make sure the package is compiled before installation
+conda activate jupyterlab-ext
+npx lerna bootstrap
+npx lerna run build --scope @tubitv/filebrowser-share-file
+
+# Disable JupyterLab share-file
+jupyter labextension disable @jupyterlab/filebrowser-extension:share-file
+jupyter labextension install packages/filebrowser-share-file
+```
+
+## Development
+
+```bash
+conda activate jupyterlab-ext
+
+# Install npm package dependencies
+npx lerna bootstrap
+
+# Develop an extension
+npx lerna run watch --stream --scope @tubitv/filebrowser-share-file
+jupyter labextension install packages/filebrowser-share-file --no-build
+jupyter lab --watch
+
+# Publish changed extensions
+npx lerna publish
+```

--- a/packages/filebrowser-share-file/babel.config.js
+++ b/packages/filebrowser-share-file/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/packages/filebrowser-share-file/jest.config.js
+++ b/packages/filebrowser-share-file/jest.config.js
@@ -1,0 +1,24 @@
+const func = require('@jupyterlab/testutils/lib/jest-config');
+
+const local = {
+  globals: { 'ts-jest': { tsConfig: 'tsconfig.json' } },
+  testRegex: `.*\.spec\.tsx?$`,
+  transform: {
+    '\\.(ts|tsx)?$': 'ts-jest',
+    '\\.(js|jsx)?$': 'babel-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(@jupyterlab/.*)/)']
+};
+
+const upstream = func('jupyterlab_filebrowser_share_file', __dirname);
+const reuseFromUpstream = [
+  'moduleNameMapper',
+  'setupFilesAfterEnv',
+  'setupFiles',
+  'moduleFileExtensions',
+];
+for(option of reuseFromUpstream) {
+  local[option] = upstream[option];
+}
+
+module.exports = local;

--- a/packages/filebrowser-share-file/package.json
+++ b/packages/filebrowser-share-file/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@tubitv/filebrowser-share-file",
+  "version": "0.1.2",
+  "description": "Custom filebrowser plugin that generates /user-redirect link",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/Tubitv/jupyterlab-extensions",
+  "bugs": {
+    "url": "https://github.com/Tubitv/jupyterlab-extensions/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Tubi Engineering",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "style": "style/index.css",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tubitv/jupyterlab-extensions.git"
+  },
+  "scripts": {
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "build": "tsc -b",
+    "watch": "tsc -b --watch",
+    "test": "npx jest"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^3.0.0",
+    "@jupyterlab/apputils": "^3.0.0",
+    "@jupyterlab/coreutils": "^5.0.0",
+    "@jupyterlab/filebrowser": "^3.0.0",
+    "@lumino/algorithm": "^1.3.3"
+  },
+  "sideEffects": [
+    "style/*.css"
+  ],
+  "jupyterlab": {
+    "extension": true
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/filebrowser-share-file/src/index.spec.ts
+++ b/packages/filebrowser-share-file/src/index.spec.ts
@@ -1,0 +1,40 @@
+import {
+  transformToUserRedirectUrl,
+  log,
+} from './index';
+
+const testUrls = {
+  original: [
+    "http://localhost:8000/lab/tree/path/to/notebook.ipynb",
+    "http://localhost:8000/user/jovyan/lab/tree/path/to/notebook.ipynb",
+    "http://localhost:8000/user/jovyan/dummy/lab/tree/path/to/notebook.ipynb",
+  ],
+  expected: [
+    "http://localhost:8000/lab/tree/path/to/notebook.ipynb",
+    "http://localhost:8000/user-redirect/lab/tree/path/to/notebook.ipynb",
+    "http://localhost:8000/user-redirect/dummy/lab/tree/path/to/notebook.ipynb",
+  ]
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('#log', () => {
+  it('should call `console.debug` with debug message if it is available', () => {
+    const debugSpy = jest.spyOn(console, 'debug');
+    const message = 'shareable link';
+    log(message);
+    expect(debugSpy.mock.calls[0][1]).toBe(message);
+  });
+});
+
+describe('#transformToUserRedirectUrl', () => {
+  it ('should transform tree url to correct user redirect url', () => {
+    testUrls.original.forEach((originalUrl, index) => {
+      const transformedUrl = transformToUserRedirectUrl(originalUrl);
+      log(transformedUrl);
+      expect(transformedUrl).toBe(testUrls.expected[index]);
+    });
+  });
+});

--- a/packages/filebrowser-share-file/src/index.ts
+++ b/packages/filebrowser-share-file/src/index.ts
@@ -1,0 +1,94 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import {
+  Clipboard
+} from '@jupyterlab/apputils';
+
+import {
+  PageConfig,
+  URLExt
+} from '@jupyterlab/coreutils';
+
+import {
+  IFileBrowserFactory
+} from '@jupyterlab/filebrowser';
+
+import {
+  toArray
+} from '@phosphor/algorithm';
+
+const shareFile: JupyterFrontEndPlugin<void> = {
+  activate: activateShareFile,
+  id: '@jupyterlab/filebrowser-extension:share-file',
+  requires: [IFileBrowserFactory],
+  autoStart: true
+};
+
+export default shareFile;
+
+/**
+ * Log debugging information
+ */
+export function log(...args: any[]): void {
+  if (console && console.debug) {
+    console.debug('[filebrowser-share-file]', ...args);
+  }
+}
+
+/**
+ * transform tree url to `/user-redirect/` url for JupyterHub
+ * see https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect
+ * @param url
+ */
+export function transformToUserRedirectUrl(url: string): string {
+  return url.replace(/\/user\/([^\/]+)\//, "/user-redirect/");
+}
+
+function activateShareFile(
+  app: JupyterFrontEnd,
+  factory: IFileBrowserFactory
+): void {
+  log('Custom plugin is activated!');
+  const { commands } = app;
+  const { tracker } = factory;
+
+  commands.addCommand("filebrowser:share-main", {
+    execute: () => {
+      const widget = tracker.currentWidget;
+      if (!widget) {
+        return;
+      }
+      // https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect
+      // Replace a URL like
+      // https://example.com/user/someone/files/shared/README.md
+      // to
+      // https://example.com/user-redirect/lab/tree/shared/README.md
+      // e.g. shared/README.md
+      const path = encodeURI(widget.selectedItems().next().path);
+      // e.g. https://domain/user/username/lab/tree
+      // e.g. https://domain/user/username/servername/lab/tree
+      const treeUrl = PageConfig.getTreeUrl();
+      // replace `/user/username/` to `/user-redirect/` if any
+      // for local JupyterLab, it won't change anything, because there is no `/user/username/` part in the URL
+      const userRedirectTreeUrl = transformToUserRedirectUrl(treeUrl);
+      // 1. local: replace https://domain/other-part with https://domain/other-part
+      // 2. default server: replace https://domain/user/usr/other-part with https://domain/user-redirect/other-part
+      // 3. named server: replace https://domain/user/usr/svc/other-part with https://domain/user-redirect/svc/other-part
+      const shareableLink = URLExt.join(userRedirectTreeUrl, path);
+      log("Tree URL is", treeUrl);
+      log("User Redirect Tree URL is", userRedirectTreeUrl);
+      log("Path is", path);
+      log("Final link is", shareableLink);
+
+      Clipboard.copyToSystem(shareableLink);
+    },
+    isVisible: () =>
+      tracker.currentWidget &&
+      toArray(tracker.currentWidget.selectedItems()).length === 1,
+    iconClass: 'jp-MaterialIcon jp-LinkIcon',
+    label: 'Copy Shareable Link'
+  });
+}

--- a/packages/filebrowser-share-file/src/index.ts
+++ b/packages/filebrowser-share-file/src/index.ts
@@ -18,11 +18,11 @@ import {
 
 import {
   toArray
-} from '@phosphor/algorithm';
+} from '@lumino/algorithm';
 
 const shareFile: JupyterFrontEndPlugin<void> = {
   activate: activateShareFile,
-  id: '@jupyterlab/filebrowser-extension:share-file',
+  id: '@tubitv/filebrowser-extension:share-file',
   requires: [IFileBrowserFactory],
   autoStart: true
 };

--- a/packages/filebrowser-share-file/tsconfig.json
+++ b/packages/filebrowser-share-file/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": false,
+    "target": "es2017",
+    "types": ["jest"]
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Reinstate copy shareable link context menu item.

Copy shareable link provided by jupyterlab 3.x on Jupyterhub 1.0 does not contain user-redirect.